### PR TITLE
Add MLB scoreboard screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,6 +83,7 @@ from mlb_standings       import (
     draw_AL_West,
     draw_AL_WildCard,
 )
+from mlb_scoreboard      import draw_mlb_scoreboard
 from draw_inside import draw_inside
 
 # ─── Logging ─────────────────────────────────────────────────────────────────
@@ -319,6 +320,7 @@ def build_screens():
 
     screens += [
         ("mlb logo",     (lambda: show_logo(mlb_logo)) if mlb_logo else None),
+        ("MLB Scoreboard", lambda: draw_mlb_scoreboard(display, transition=True)),
         ("NL Overview",  lambda: draw_NL_Overview(display, transition=True)),
         ("NL East",      lambda: draw_NL_East(display, transition=True)),
         ("NL Central",   lambda: draw_NL_Central(display, transition=True)),

--- a/mlb_scoreboard.py
+++ b/mlb_scoreboard.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+mlb_scoreboard.py
+
+Render a scrolling MLB scoreboard showing all games for the current day.
+Layout:
+    • Title "MLB Scoreboard" centered at the top.
+    • Each game occupies two rows arranged in five conceptual columns:
+        [Away Score] [Away Logo] [ @ ] [Home Logo] [Home Score]
+      The second row centers the status/time text in the middle column.
+    • When the combined height exceeds the OLED, the list scrolls top → bottom.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import time
+from typing import Iterable, Optional
+
+import requests
+from PIL import Image, ImageDraw
+
+from config import (
+    WIDTH,
+    HEIGHT,
+    FONT_TITLE_SPORTS,
+    FONT_TEAM_SPORTS,
+    FONT_STATUS,
+    CENTRAL_TIME,
+    IMAGES_DIR,
+)
+from utils import (
+    clear_display,
+    clone_font,
+    get_mlb_abbreviation,
+    load_team_logo,
+    log_call,
+)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+TITLE                 = "MLB Scoreboard"
+TITLE_GAP             = 8
+BLOCK_SPACING         = 6
+SCORE_ROW_H           = 26
+STATUS_ROW_H          = 14
+SCROLL_STEP           = 1
+SCROLL_DELAY          = 0.04
+SCROLL_PAUSE_TOP      = 0.75
+SCROLL_PAUSE_BOTTOM   = 0.5
+REQUEST_TIMEOUT       = 10
+
+COL_WIDTHS = [28, 24, 24, 24, 28]  # total = 128 (WIDTH)
+COL_X = [0]
+for w in COL_WIDTHS:
+    COL_X.append(COL_X[-1] + w)
+
+SCORE_FONT   = clone_font(FONT_TEAM_SPORTS, 14)
+STATUS_FONT  = clone_font(FONT_STATUS, 13)
+CENTER_FONT  = clone_font(FONT_STATUS, 15)
+TITLE_FONT   = FONT_TITLE_SPORTS
+LOGO_HEIGHT  = 22
+LOGO_DIR     = os.path.join(IMAGES_DIR, "mlb")
+
+# Cache for resized logos {abbr: Image}
+_LOGO_CACHE: dict[str, Optional[Image.Image]] = {}
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+def _load_logo_cached(abbr: str) -> Optional[Image.Image]:
+    if abbr in _LOGO_CACHE:
+        return _LOGO_CACHE[abbr]
+    logo = load_team_logo(LOGO_DIR, abbr, height=LOGO_HEIGHT)
+    _LOGO_CACHE[abbr] = logo
+    return logo
+
+
+def _team_text_abbr(team: dict) -> str:
+    raw = (team or {}).get("abbreviation")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip().upper()
+    name = (team or {}).get("name", "")
+    return get_mlb_abbreviation(name).upper()
+
+
+def _team_logo_abbr(team: dict) -> str:
+    for key in ("abbreviation", "fileCode"):
+        val = (team or {}).get(key)
+        if isinstance(val, str) and val.strip():
+            cand = val.strip().upper()
+            if os.path.exists(os.path.join(LOGO_DIR, f"{cand}.png")):
+                return cand
+    name = (team or {}).get("name", "")
+    abbr = get_mlb_abbreviation(name).upper()
+    if os.path.exists(os.path.join(LOGO_DIR, f"{abbr}.png")):
+        return abbr
+    return ""
+
+
+def _score_string(side: dict) -> tuple[str, Optional[int]]:
+    team = (side or {}).get("team", {})
+    abbr = _team_text_abbr(team)
+    score = (side or {}).get("score")
+    score_txt = "—" if score is None else str(score)
+    return f"{abbr} {score_txt}".strip(), score if isinstance(score, int) else None
+
+
+def _final_inning(linescore: dict) -> Optional[int]:
+    if not isinstance(linescore, dict):
+        return None
+    try:
+        cur = int(linescore.get("currentInning"))
+        if cur:
+            return cur
+    except Exception:
+        pass
+    innings = linescore.get("innings")
+    if isinstance(innings, Iterable):
+        for inning in reversed(list(innings)):
+            try:
+                num = int(inning.get("num"))
+                if num:
+                    return num
+            except Exception:
+                continue
+    return None
+
+
+def _format_status(game: dict) -> str:
+    status = (game or {}).get("status", {}) or {}
+    linescore = (game or {}).get("linescore", {}) or {}
+    abstract = (status.get("abstractGameState") or "").lower()
+    detailed = status.get("detailedState") or ""
+    code = (status.get("statusCode") or "").upper()
+
+    detailed_lower = detailed.lower()
+
+    if "postponed" in detailed_lower:
+        return "Postponed"
+    if "suspended" in detailed_lower:
+        return detailed
+
+    if abstract in ("final", "completed") or code in {"F", "O"} or "final" in detailed_lower:
+        innings = _final_inning(linescore)
+        scheduled = linescore.get("scheduledInnings")
+        if isinstance(innings, int):
+            if isinstance(scheduled, int) and innings != scheduled:
+                return f"Final/{innings}"
+            if innings > 9:
+                return f"Final/{innings}"
+        return "Final"
+
+    if abstract == "live" or code == "I" or "progress" in detailed_lower:
+        inning_state = (linescore.get("inningState") or "").strip()
+        inning_ord = (linescore.get("currentInningOrdinal") or "").strip()
+        if inning_state and inning_ord:
+            return f"{inning_state} {inning_ord}"
+        if detailed:
+            return detailed
+        return "In Progress"
+
+    if "delay" in detailed_lower:
+        return detailed
+
+    start_local = game.get("_start_local")
+    if isinstance(start_local, datetime.datetime):
+        return start_local.strftime("%I:%M %p").lstrip("0")
+
+    if detailed:
+        return detailed
+    return (status.get("status") or "TBD")
+
+
+def _center_text(draw: ImageDraw.ImageDraw, text: str, font, x: int, width: int,
+                 y: int, height: int, *, fill=(255, 255, 255)):
+    if not text:
+        return
+    try:
+        l, t, r, b = draw.textbbox((0, 0), text, font=font)
+        tw, th = r - l, b - t
+        tx = x + (width - tw) // 2 - l
+        ty = y + (height - th) // 2 - t
+    except Exception:
+        tw, th = draw.textsize(text, font=font)
+        tx = x + (width - tw) // 2
+        ty = y + (height - th) // 2
+    draw.text((tx, ty), text, font=font, fill=fill)
+
+
+def _draw_game_block(canvas: Image.Image, draw: ImageDraw.ImageDraw, game: dict, top: int):
+    teams = (game or {}).get("teams", {})
+    away = teams.get("away", {})
+    home = teams.get("home", {})
+
+    away_text, _ = _score_string(away)
+    home_text, _ = _score_string(home)
+
+    # Score row (5 columns)
+    score_top = top
+    for idx, text in ((0, away_text), (2, "@"), (4, home_text)):
+        font = SCORE_FONT if idx != 2 else CENTER_FONT
+        fill = (255, 255, 255)
+        _center_text(draw, text, font, COL_X[idx], COL_WIDTHS[idx], score_top, SCORE_ROW_H, fill=fill)
+
+    # Logos
+    for idx, team_side in ((1, away), (3, home)):
+        team_obj = (team_side or {}).get("team", {})
+        abbr = _team_logo_abbr(team_obj)
+        logo = _load_logo_cached(abbr) if abbr else None
+        if not logo:
+            continue
+        x0 = COL_X[idx] + (COL_WIDTHS[idx] - logo.width) // 2
+        y0 = score_top + (SCORE_ROW_H - logo.height) // 2
+        canvas.paste(logo, (x0, y0), logo)
+
+    # Status row (center column text)
+    status_top = score_top + SCORE_ROW_H
+    status_text = _format_status(game)
+    _center_text(draw, status_text, STATUS_FONT, COL_X[2], COL_WIDTHS[2], status_top, STATUS_ROW_H)
+
+
+def _compose_canvas(games: list[dict]) -> Image.Image:
+    if not games:
+        return Image.new("RGB", (WIDTH, HEIGHT), "black")
+    block_height = SCORE_ROW_H + STATUS_ROW_H
+    total_height = block_height * len(games)
+    if len(games) > 1:
+        total_height += BLOCK_SPACING * (len(games) - 1)
+    canvas = Image.new("RGB", (WIDTH, total_height), "black")
+    draw = ImageDraw.Draw(canvas)
+
+    y = 0
+    for idx, game in enumerate(games):
+        _draw_game_block(canvas, draw, game, y)
+        y += SCORE_ROW_H + STATUS_ROW_H
+        if idx < len(games) - 1:
+            # separator line and spacing
+            sep_y = y + BLOCK_SPACING // 2
+            draw.line((10, sep_y, WIDTH - 10, sep_y), fill=(45, 45, 45))
+            y += BLOCK_SPACING
+    return canvas
+
+
+def _timestamp_to_local(ts: str) -> Optional[datetime.datetime]:
+    if not ts:
+        return None
+    try:
+        dt = datetime.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt.astimezone(CENTRAL_TIME)
+    except Exception:
+        return None
+
+
+def _hydrate_games(raw_games: Iterable[dict]) -> list[dict]:
+    games: list[dict] = []
+    for game in raw_games:
+        game = game or {}
+        start_local = _timestamp_to_local(game.get("gameDate"))
+        if start_local:
+            game["_start_local"] = start_local
+            game["_start_sort"] = start_local.timestamp()
+        else:
+            game["_start_sort"] = float("inf")
+        games.append(game)
+    games.sort(key=lambda g: (g.get("_start_sort", float("inf")), g.get("gamePk", 0)))
+    return games
+
+
+def _fetch_todays_games() -> list[dict]:
+    today = datetime.datetime.now(CENTRAL_TIME).date()
+    url = (
+        "https://statsapi.mlb.com/api/v1/schedule"
+        f"?sportId=1&date={today.isoformat()}&hydrate=team,linescore"
+    )
+    try:
+        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:
+        logging.error("Failed to fetch MLB schedule: %s", exc)
+        return []
+
+    raw_games: list[dict] = []
+    for day in data.get("dates", []):
+        raw_games.extend(day.get("games", []) or [])
+    return _hydrate_games(raw_games)
+
+
+def _render_scoreboard(games: list[dict]) -> Image.Image:
+    canvas = _compose_canvas(games)
+
+    # Measure title height on a throwaway canvas to size the final image precisely.
+    dummy = Image.new("RGB", (WIDTH, 10), "black")
+    dd = ImageDraw.Draw(dummy)
+    try:
+        l, t, r, b = dd.textbbox((0, 0), TITLE, font=TITLE_FONT)
+        title_h = b - t
+    except Exception:
+        _, title_h = dd.textsize(TITLE, font=TITLE_FONT)
+
+    content_top = title_h + TITLE_GAP
+    img_height = max(HEIGHT, content_top + canvas.height)
+    img = Image.new("RGB", (WIDTH, img_height), "black")
+    draw = ImageDraw.Draw(img)
+
+    # Title (recompute placement on the real canvas)
+    try:
+        l, t, r, b = draw.textbbox((0, 0), TITLE, font=TITLE_FONT)
+        tw, th = r - l, b - t
+        tx = (WIDTH - tw) // 2 - l
+        ty = 0 - t
+    except Exception:
+        tw, th = draw.textsize(TITLE, font=TITLE_FONT)
+        tx = (WIDTH - tw) // 2
+        ty = 0
+    draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
+
+    img.paste(canvas, (0, content_top))
+    return img
+
+
+def _scroll_display(display, full_img: Image.Image):
+    if full_img.height <= HEIGHT:
+        display.image(full_img)
+        display.show()
+        return
+
+    max_offset = full_img.height - HEIGHT
+    frame = full_img.crop((0, 0, WIDTH, HEIGHT))
+    display.image(frame)
+    display.show()
+    time.sleep(SCROLL_PAUSE_TOP)
+
+    for offset in range(SCROLL_STEP, max_offset + 1, SCROLL_STEP):
+        frame = full_img.crop((0, offset, WIDTH, offset + HEIGHT))
+        display.image(frame)
+        display.show()
+        time.sleep(SCROLL_DELAY)
+
+    time.sleep(SCROLL_PAUSE_BOTTOM)
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+@log_call
+def draw_mlb_scoreboard(display, transition: bool = False):
+    games = _fetch_todays_games()
+
+    if not games:
+        clear_display(display)
+        img = Image.new("RGB", (WIDTH, HEIGHT), "black")
+        draw = ImageDraw.Draw(img)
+        try:
+            l, t, r, b = draw.textbbox((0, 0), TITLE, font=TITLE_FONT)
+            tw, th = r - l, b - t
+            tx = (WIDTH - tw) // 2 - l
+            ty = 0 - t
+        except Exception:
+            tw, th = draw.textsize(TITLE, font=TITLE_FONT)
+            tx = (WIDTH - tw) // 2
+            ty = 0
+        draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
+        _center_text(draw, "No games today", STATUS_FONT, 0, WIDTH, HEIGHT // 2 - STATUS_ROW_H // 2, STATUS_ROW_H)
+        if transition:
+            return img
+        display.image(img)
+        display.show()
+        time.sleep(SCROLL_PAUSE_BOTTOM)
+        return None
+
+    full_img = _render_scoreboard(games)
+    if transition:
+        _scroll_display(display, full_img)
+        return None
+
+    if full_img.height <= HEIGHT:
+        display.image(full_img)
+        display.show()
+        time.sleep(SCROLL_PAUSE_BOTTOM)
+    else:
+        _scroll_display(display, full_img)
+    return None
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from utils import Display
+
+    disp = Display()
+    try:
+        draw_mlb_scoreboard(disp)
+    finally:
+        clear_display(disp)

--- a/screens_catalog.py
+++ b/screens_catalog.py
@@ -10,7 +10,7 @@ SCREEN_IDS = [
     "cubs last", "cubs result", "cubs live", "cubs next",
     "sox logo", "sox stand1", "sox stand2",
     "sox last", "sox live", "sox next",
-    "mlb logo",
+    "mlb logo", "MLB Scoreboard",
     "NL Overview", "NL East", "NL Central", "NL West", "NL Wild Card"
     "AL Overview", "AL East", "AL Central", "AL West", "AL Wild Card"
 ]

--- a/screens_config.json
+++ b/screens_config.json
@@ -29,6 +29,7 @@
     "sox live": 0,
     "sox next": 0,
     "mlb logo": 0,
+    "MLB Scoreboard": 1,
     "NL Overview": 0,
     "NL East": 0,
     "NL Central": 0,

--- a/test_screens.py
+++ b/test_screens.py
@@ -23,7 +23,7 @@ def list_screens(script_dir, namespace):
     # scroll logos
     screens.append({"name":"scroll_all_logos","type":"scroll"})
     for fname in sorted(os.listdir(script_dir)):
-        if not (fname.startswith("draw_") and fname.endswith(".py")):
+        if not (fname.endswith(".py") and (fname.startswith("draw_") or fname == "mlb_scoreboard.py")):
             continue
         mod = os.path.splitext(fname)[0]
         path= os.path.join(script_dir,fname)


### PR DESCRIPTION
## Summary
- add a new MLB scoreboard screen that fetches the current day schedule and scrolls through each matchup with scores, logos, and status updates
- hook the scoreboard into the main screen sequence, configuration, catalog, and test harness entries so it follows the MLB logo

## Testing
- python3 -m compileall mlb_scoreboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d94b4063f08322ae50704daf7bdec8