### PR TITLE
Add shared HTTP session with NHL headers

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -1,0 +1,72 @@
+"""Shared HTTP client utilities with browser-like headers and retries."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_HEADERS: Dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+NHL_HEADERS: Dict[str, str] = {
+    "Origin": "https://www.nhl.com",
+    "Referer": "https://www.nhl.com/",
+}
+
+_RETRY = Retry(
+    total=4,
+    connect=4,
+    read=4,
+    backoff_factor=0.5,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=False,
+    raise_on_status=False,
+)
+
+def _build_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update(DEFAULT_HEADERS)
+    adapter = HTTPAdapter(max_retries=_RETRY)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+_SESSION = _build_session()
+
+
+def get_session() -> requests.Session:
+    """Return the shared HTTP session."""
+    return _SESSION
+
+
+def request_json(
+    url: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: float = 10.0,
+    headers: Optional[Dict[str, str]] = None,
+    quiet: bool = False,
+    session: Optional[requests.Session] = None,
+    **kwargs: Any,
+) -> Optional[Dict[str, Any]]:
+    """Perform a GET request that returns JSON, with optional quiet logging."""
+    sess = session or _SESSION
+    try:
+        response = sess.get(url, params=params, headers=headers, timeout=timeout, **kwargs)
+        response.raise_for_status()
+        return response.json()
+    except Exception as exc:  # pragma: no cover - defensive network layer
+        if not quiet:
+            logging.warning("Request failed: %s (%s)", url, exc)
+        return None

--- a/nhl_scoreboard.py
+++ b/nhl_scoreboard.py
@@ -15,7 +15,6 @@ import os
 import time
 from typing import Any, Dict, Iterable, Optional
 
-import requests
 from PIL import Image, ImageDraw
 
 from config import (
@@ -33,6 +32,7 @@ from utils import (
     load_team_logo,
     log_call,
 )
+from http_client import NHL_HEADERS, get_session
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 TITLE               = "NHL Scoreboard"
@@ -60,6 +60,8 @@ LOGO_HEIGHT = 22
 LOGO_DIR    = os.path.join(IMAGES_DIR, "nhl")
 
 _LOGO_CACHE: dict[str, Optional[Image.Image]] = {}
+
+_SESSION = get_session()
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -449,7 +451,7 @@ def _map_api_web_game(game: Dict[str, Any], day: datetime.date) -> Dict[str, Any
 def _fetch_games_api_web(day: datetime.date) -> list[dict]:
     url = API_WEB_SCOREBOARD_URL.format(date=day.isoformat())
     try:
-        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+        response = _SESSION.get(url, timeout=REQUEST_TIMEOUT, headers=NHL_HEADERS)
         response.raise_for_status()
         data = response.json()
     except Exception as exc:
@@ -490,7 +492,7 @@ def _fetch_games_for_date(day: datetime.date) -> list[dict]:
     )
     data: Optional[Dict[str, Any]] = None
     try:
-        response = requests.get(stats_url, timeout=REQUEST_TIMEOUT)
+        response = _SESSION.get(stats_url, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
         data = response.json()
     except Exception as exc:
@@ -608,3 +610,4 @@ if __name__ == "__main__":  # pragma: no cover
         draw_nhl_scoreboard(disp)
     finally:
         clear_display(disp)
+


### PR DESCRIPTION
## Summary
- add a shared HTTP client with browser-like headers and retries for NHL endpoints
- update Blackhawks schedule fetchers to use the shared session and NHL headers
- switch the NHL scoreboard fetchers to the shared client to reduce connection resets

## Testing
- python -m compileall data_fetch.py draw_hawks_schedule.py nhl_scoreboard.py http_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d98e2f579c8322975b69ef18e11104