### PR TITLE
Show non-Sunday day on upcoming NFL games

### DIFF
--- a/nfl_scoreboard.py
+++ b/nfl_scoreboard.py
@@ -154,7 +154,11 @@ def _format_status(game: dict) -> str:
     if state == "pre":
         start_local = game.get("_start_local")
         if isinstance(start_local, datetime.datetime):
-            return start_local.strftime("%I:%M %p").lstrip("0")
+            time_text = start_local.strftime("%I:%M %p").lstrip("0")
+            if start_local.weekday() != 6:  # Not Sunday
+                day_text = start_local.strftime("%a")
+                return f"{day_text} {time_text}"
+            return time_text
         return short_detail or detail or "TBD"
 
     return short_detail or detail or "TBD"


### PR DESCRIPTION
## Summary
- include the day of week for non-Sunday NFL games that have not yet started

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b88acda88322bbee2e7df1d5c162