### PR TITLE
Skip duplicate next home game screens

### DIFF
--- a/draw_hawks_schedule.py
+++ b/draw_hawks_schedule.py
@@ -736,7 +736,7 @@ def _format_next_bottom(
     date_str = local.strftime("%a %b %-d") if os.name != "nt" else local.strftime("%a %b %#d")
     return f"{date_str} {time_str}"
 
-def _draw_next_card(display, game: Dict, *, title: str, transition: bool=False):
+def _draw_next_card(display, game: Dict, *, title: str, transition: bool=False, log_label: str="hawks next"):
     """
     Next-game card with:
       - Title (MLB font)
@@ -745,7 +745,7 @@ def _draw_next_card(display, game: Dict, *, title: str, transition: bool=False):
       - Bottom line that always includes game time
     """
     if not isinstance(game, dict):
-        logging.warning("hawks next: missing payload")
+        logging.warning("%s: missing payload", log_label)
         return None
 
     # Raw teams (for names); tris for local logo filenames
@@ -950,9 +950,9 @@ def draw_sports_screen_hawks(display, game, transition: bool=False):
     "Next Hawks game" card with '@ FULLNAME' / 'vs. FULLNAME', logos (local PNGs, centered and larger), and bottom time.
     Uses the provided 'game' payload from your scheduler for the next slot.
     """
-    return _draw_next_card(display, game, title="Next Hawks game:", transition=transition)
+    return _draw_next_card(display, game, title="Next Hawks game:", transition=transition, log_label="hawks next")
 
 
 def draw_hawks_next_home_game(display, game, transition: bool=False):
     """Dedicated "Next Home Game..." card using the same layout as the next-game screen."""
-    return _draw_next_card(display, game, title="Next Home Game...", transition=transition)
+    return _draw_next_card(display, game, title="Next Home Game...", transition=transition, log_label="hawks next home")

--- a/main.py
+++ b/main.py
@@ -310,7 +310,16 @@ def build_screens():
             ("hawks last", lambda: draw_last_hawks_game(display, cache["hawks"]["last"], transition=True)),
             ("hawks live", lambda: draw_live_hawks_game(display, cache["hawks"]["live"], transition=True)),
             ("hawks next", lambda: draw_sports_screen_hawks(display, cache["hawks"]["next"], transition=True)),
-            ("hawks next home", lambda: draw_hawks_next_home_game(display, cache["hawks"]["next_home"], transition=True)),
+            (
+                "hawks next home",
+                (
+                    lambda: draw_hawks_next_home_game(
+                        display,
+                        cache["hawks"]["next_home"],
+                        transition=True,
+                    )
+                ) if cache["hawks"]["next_home"] else None,
+            ),
             ("nhl logo",   (lambda: show_logo(nhl_logo)) if nhl_logo else None),
             ("NHL Scoreboard", lambda: draw_nhl_scoreboard(display, transition=True)),
         ]
@@ -325,7 +334,16 @@ def build_screens():
             ("cubs result", lambda: draw_cubs_result(display, cache["cubs"]["last"], transition=True)),
             ("cubs live",   lambda: draw_box_score(display,  cache["cubs"]["live"], "Cubs Live...", transition=True)),
             ("cubs next",   lambda: draw_sports_screen(display, cache["cubs"]["next"], "Next Cubs game...", transition=True)),
-            ("cubs next home", lambda: draw_next_home_game(display, cache["cubs"]["next_home"], transition=True)),
+            (
+                "cubs next home",
+                (
+                    lambda: draw_next_home_game(
+                        display,
+                        cache["cubs"]["next_home"],
+                        transition=True,
+                    )
+                ) if cache["cubs"]["next_home"] else None,
+            ),
         ]
         screens = [s for s in screens if s]
 
@@ -337,7 +355,16 @@ def build_screens():
             ("sox last",   lambda: draw_last_game(display, cache["sox"]["last"], "Last Sox game...", transition=True)),
             ("sox live",   lambda: draw_box_score(display, cache["sox"]["live"], "Sox Live...", transition=True)),
             ("sox next",   lambda: draw_sports_screen(display, cache["sox"]["next"], "Next Sox game...", transition=True)),
-            ("sox next home", lambda: draw_next_home_game(display, cache["sox"]["next_home"], transition=True)),
+            (
+                "sox next home",
+                (
+                    lambda: draw_next_home_game(
+                        display,
+                        cache["sox"]["next_home"],
+                        transition=True,
+                    )
+                ) if cache["sox"]["next_home"] else None,
+            ),
         ]
         screens = [s for s in screens if s]
 


### PR DESCRIPTION
## Summary
- stop scheduling the Hawks, Cubs, and Sox next-home cards when no dedicated payload is available
- log when an MLB team's next home game duplicates its upcoming game to mirror the NHL behaviour

## Testing
- python -m compileall data_fetch.py draw_hawks_schedule.py mlb_schedule.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68daf1c263988322ad535c2e97080b89