### PR TITLE
Fix MLB scoreboard fallback when previous day has no games

### DIFF
--- a/mlb_scoreboard.py
+++ b/mlb_scoreboard.py
@@ -365,7 +365,16 @@ def _scroll_display(display, full_img: Image.Image):
 # ─── Public API ───────────────────────────────────────────────────────────────
 @log_call
 def draw_mlb_scoreboard(display, transition: bool = False):
-    games = _fetch_games_for_date(_scoreboard_date())
+    now = datetime.datetime.now(CENTRAL_TIME)
+    target_date = _scoreboard_date(now)
+    games = _fetch_games_for_date(target_date)
+
+    if not games:
+        today = now.date()
+        if today != target_date:
+            today_games = _fetch_games_for_date(today)
+            if today_games:
+                games = today_games
 
     if not games:
         clear_display(display)


### PR DESCRIPTION
## Summary
- ensure the MLB scoreboard falls back to today's schedule when the previous day's slate is empty
- keep the existing early morning behavior while avoiding a false "No games today" message when games are scheduled later

## Testing
- not run (networked API access is restricted in CI)


------
https://chatgpt.com/codex/tasks/task_e_68df0a5441bc832281e4b8285715fd19