### PR TITLE
Capture full scoreboard images for screenshots

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ from config import (
 )
 from utils import (
     Display,
+    ScreenImage,
     clear_display,
     draw_text_centered,
     animate_fade_in,
@@ -525,13 +526,21 @@ def main_loop():
                     f"🎬 Presenting '{sid}' (loop {loop_count}, every {freq} loop(s))"
                 )
                 try:
-                    img = fn()
+                    result = fn()
                 except Exception as e:
                     logging.error(f"Error in screen '{sid}': {e}")
                     continue
 
+                already_displayed = False
+                img = None
+                if isinstance(result, ScreenImage):
+                    img = result.image
+                    already_displayed = result.displayed
+                elif isinstance(result, Image.Image):
+                    img = result
+
                 # Logos return an image directly
-                if "logo" in sid and img:
+                if "logo" in sid and isinstance(img, Image.Image):
                     if ENABLE_SCREENSHOTS:
                         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
                         path = os.path.join(SCREENSHOT_DIR, f"{sid.replace(' ', '_')}_{ts}.png")
@@ -548,8 +557,9 @@ def main_loop():
                     continue
 
                 # Content screens
-                if img:
-                    animate_fade_in(display, img, steps=8, delay=0.015)
+                if isinstance(img, Image.Image):
+                    if not already_displayed:
+                        animate_fade_in(display, img, steps=8, delay=0.015)
                     if ENABLE_SCREENSHOTS:
                         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
                         safe = sid.replace(" ", "_").replace(".", "")

--- a/mlb_scoreboard.py
+++ b/mlb_scoreboard.py
@@ -34,6 +34,7 @@ from config import (
     IMAGES_DIR,
 )
 from utils import (
+    ScreenImage,
     clear_display,
     clone_font,
     get_mlb_abbreviation,
@@ -367,7 +368,7 @@ def _scroll_display(display, full_img: Image.Image):
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 @log_call
-def draw_mlb_scoreboard(display, transition: bool = False):
+def draw_mlb_scoreboard(display, transition: bool = False) -> ScreenImage:
     now = datetime.datetime.now(CENTRAL_TIME)
     target_date = _scoreboard_date(now)
     games = _fetch_games_for_date(target_date)
@@ -395,16 +396,16 @@ def draw_mlb_scoreboard(display, transition: bool = False):
         draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
         _center_text(draw, "No games today", STATUS_FONT, 0, WIDTH, HEIGHT // 2 - STATUS_ROW_H // 2, STATUS_ROW_H)
         if transition:
-            return img
+            return ScreenImage(img, displayed=False)
         display.image(img)
         display.show()
         time.sleep(SCROLL_PAUSE_BOTTOM)
-        return None
+        return ScreenImage(img, displayed=True)
 
     full_img = _render_scoreboard(games)
     if transition:
         _scroll_display(display, full_img)
-        return None
+        return ScreenImage(full_img, displayed=True)
 
     if full_img.height <= HEIGHT:
         display.image(full_img)
@@ -412,7 +413,7 @@ def draw_mlb_scoreboard(display, transition: bool = False):
         time.sleep(SCROLL_PAUSE_BOTTOM)
     else:
         _scroll_display(display, full_img)
-    return None
+    return ScreenImage(full_img, displayed=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/nba_scoreboard.py
+++ b/nba_scoreboard.py
@@ -33,6 +33,7 @@ from config import (
     IMAGES_DIR,
 )
 from utils import (
+    ScreenImage,
     clear_display,
     clone_font,
     load_team_logo,
@@ -659,7 +660,7 @@ def _scroll_display(display, full_img: Image.Image):
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 @log_call
-def draw_nba_scoreboard(display, transition: bool = False):
+def draw_nba_scoreboard(display, transition: bool = False) -> ScreenImage:
     games = _fetch_games_for_date(_scoreboard_date())
 
     if not games:
@@ -678,25 +679,24 @@ def draw_nba_scoreboard(display, transition: bool = False):
         draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
         _center_text(draw, "No games today", STATUS_FONT, 0, WIDTH, HEIGHT // 2 - STATUS_ROW_H // 2, STATUS_ROW_H)
         if transition:
-            return img
+            return ScreenImage(img, displayed=False)
         display.image(img)
         display.show()
         time.sleep(SCROLL_PAUSE_BOTTOM)
-        return None
+        return ScreenImage(img, displayed=True)
 
     full_img = _render_scoreboard(games)
     if transition:
         _scroll_display(display, full_img)
-        return None
+        return ScreenImage(full_img, displayed=True)
 
     if full_img.height <= HEIGHT:
         display.image(full_img)
         display.show()
         time.sleep(SCROLL_PAUSE_BOTTOM)
-        return None
-
-    _scroll_display(display, full_img)
-    return None
+    else:
+        _scroll_display(display, full_img)
+    return ScreenImage(full_img, displayed=True)
 
 
 @log_call

--- a/nfl_scoreboard.py
+++ b/nfl_scoreboard.py
@@ -28,6 +28,7 @@ from config import (
     IMAGES_DIR,
 )
 from utils import (
+    ScreenImage,
     clear_display,
     clone_font,
     load_team_logo,
@@ -357,7 +358,7 @@ def _scroll_display(display, full_img: Image.Image):
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 @log_call
-def draw_nfl_scoreboard(display, transition: bool = False):
+def draw_nfl_scoreboard(display, transition: bool = False) -> ScreenImage:
     games = _fetch_games_for_week()
 
     if not games:
@@ -376,16 +377,16 @@ def draw_nfl_scoreboard(display, transition: bool = False):
         draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
         _center_text(draw, "No games", STATUS_FONT, 0, WIDTH, HEIGHT // 2 - STATUS_ROW_H // 2, STATUS_ROW_H)
         if transition:
-            return img
+            return ScreenImage(img, displayed=False)
         display.image(img)
         display.show()
         time.sleep(SCROLL_PAUSE_BOTTOM)
-        return None
+        return ScreenImage(img, displayed=True)
 
     full_img = _render_scoreboard(games)
     if transition:
         _scroll_display(display, full_img)
-        return None
+        return ScreenImage(full_img, displayed=True)
 
     if full_img.height <= HEIGHT:
         display.image(full_img)
@@ -393,7 +394,7 @@ def draw_nfl_scoreboard(display, transition: bool = False):
         time.sleep(SCROLL_PAUSE_BOTTOM)
     else:
         _scroll_display(display, full_img)
-    return None
+    return ScreenImage(full_img, displayed=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/nhl_scoreboard.py
+++ b/nhl_scoreboard.py
@@ -31,6 +31,7 @@ from config import (
     IMAGES_DIR,
 )
 from utils import (
+    ScreenImage,
     clear_display,
     clone_font,
     load_team_logo,
@@ -830,7 +831,7 @@ def _scroll_display(display, full_img: Image.Image):
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 @log_call
-def draw_nhl_scoreboard(display, transition: bool = False):
+def draw_nhl_scoreboard(display, transition: bool = False) -> ScreenImage:
     games = _fetch_games_for_date(_scoreboard_date())
 
     if not games:
@@ -849,16 +850,16 @@ def draw_nhl_scoreboard(display, transition: bool = False):
         draw.text((tx, ty), TITLE, font=TITLE_FONT, fill=(255, 255, 255))
         _center_text(draw, "No games", STATUS_FONT, 0, WIDTH, HEIGHT // 2 - STATUS_ROW_H // 2, STATUS_ROW_H)
         if transition:
-            return img
+            return ScreenImage(img, displayed=False)
         display.image(img)
         display.show()
         time.sleep(SCROLL_PAUSE_BOTTOM)
-        return None
+        return ScreenImage(img, displayed=True)
 
     full_img = _render_scoreboard(games)
     if transition:
         _scroll_display(display, full_img)
-        return None
+        return ScreenImage(full_img, displayed=True)
 
     if full_img.height <= HEIGHT:
         display.image(full_img)
@@ -866,7 +867,7 @@ def draw_nhl_scoreboard(display, transition: bool = False):
         time.sleep(SCROLL_PAUSE_BOTTOM)
     else:
         _scroll_display(display, full_img)
-    return None
+    return ScreenImage(full_img, displayed=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/test_screens.py
+++ b/test_screens.py
@@ -75,8 +75,13 @@ def invoke_screen(entry, display, namespace):
                 args.append(getattr(module,f"get_{p}")())
             else:
                 args.append(None)
-        img=fn(*args)
-        if img:
+        result = fn(*args)
+        already_displayed = False
+        img = result
+        if isinstance(result, utils.ScreenImage):
+            img = result.image
+            already_displayed = result.displayed
+        if img and not already_displayed:
             display.image(img)
         display.show()
         time.sleep(SCREEN_DELAY)

--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,7 @@ import os
 import random
 import subprocess
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import functools
@@ -85,6 +86,24 @@ class Display:
     def show(self):
         # No-op: ShowImage pushes the buffer
         pass
+
+
+@dataclass
+class ScreenImage:
+    """Container for a rendered screen image.
+
+    Attributes
+    ----------
+    image:
+        The full PIL image representing the screen.
+    displayed:
+        Whether the image has already been pushed to the display by the
+        originating function. This allows callers to skip redundant redraws
+        while still accessing the image data (e.g., for screenshots).
+    """
+
+    image: Image.Image
+    displayed: bool = False
 
 # ─── Basic utilities ────────────────────────────────────────────────────────
 @log_call


### PR DESCRIPTION
## Summary
- add a ScreenImage container so renderers can share display metadata with callers
- have each scoreboard renderer return the full scrolling image via ScreenImage for screenshot exports
- teach the main loop and test harness to respect ScreenImage, skipping duplicate draws while still saving screenshots

## Testing
- python -m compileall utils.py main.py nba_scoreboard.py nhl_scoreboard.py mlb_scoreboard.py nfl_scoreboard.py test_screens.py

------
https://chatgpt.com/codex/tasks/task_e_68e58a9592148322ae6bdf781fca0039